### PR TITLE
hotfix: report deployed version from package metadata

### DIFF
--- a/app/api/docs/route.ts
+++ b/app/api/docs/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
+import packageJson from '../../../package.json';
 
 const openApiSpec = {
   openapi: '3.0.0',
   info: {
     title: 'ClawdMarket API',
-    version: '1.0.0',
+    version: packageJson.version,
     description: 'Agent marketplace for compute, skills, data, and bounties',
   },
   servers: [

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server';
+import packageJson from '../../../package.json';
 
 export async function GET() {
   return NextResponse.json({
     status: 'ok',
-    version: '1.0.0',
+    version: packageJson.version,
     timestamp: new Date().toISOString(),
   });
 }


### PR DESCRIPTION
## Fix
- make /api/health version dynamic from package.json
- make OpenAPI info.version dynamic from package.json

## Why
Production was deployed but endpoints still reported 1.0.0 due to hardcoded literals.

## Validation
- npm run build
