### PR TITLE
feat: add operator analytics dashboard tab

### DIFF
--- a/app/api/analytics/summary/route.ts
+++ b/app/api/analytics/summary/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { api_keys, analytics_events, listings, trades } from '@/lib/schema';
+import { authenticateRequest } from '@/lib/auth';
+import { gte } from 'drizzle-orm';
+
+async function ensureAnalyticsTable() {
+  await (db as any).$client.execute({
+    sql: `CREATE TABLE IF NOT EXISTS analytics_events (
+      id TEXT PRIMARY KEY,
+      user_id TEXT,
+      event_type TEXT NOT NULL,
+      metadata TEXT,
+      ip_hash TEXT,
+      created_at INTEGER NOT NULL
+    )`,
+    args: [],
+  });
+}
+
+export async function GET(req: NextRequest) {
+  const authHeader = req.headers.get('authorization');
+  const cookieToken = req.cookies.get('auth-token')?.value;
+  const auth = await authenticateRequest(authHeader || (cookieToken ? `Bearer ${cookieToken}` : null));
+
+  if (!auth) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    await ensureAnalyticsTable();
+
+    const [allTrades, allListings, allApiKeys] = await Promise.all([
+      db.select().from(trades),
+      db.select().from(listings),
+      db.select().from(api_keys),
+    ]);
+
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const recentEvents = await db
+      .select()
+      .from(analytics_events)
+      .where(gte(analytics_events.created_at, sevenDaysAgo));
+
+    const tradeByStatus = {
+      pending: allTrades.filter((t) => t.status === 'pending').length,
+      completed: allTrades.filter((t) => t.status === 'completed').length,
+      disputed: allTrades.filter((t) => t.status === 'disputed').length,
+    };
+
+    const listingFunnel = {
+      active: allListings.filter((l) => l.status === 'active').length,
+      sold: allListings.filter((l) => l.status === 'sold').length,
+      expired: allListings.filter((l) => l.status === 'expired').length,
+      total: allListings.length,
+    };
+
+    const now = Date.now();
+    const thirtyDaysAgo = new Date(now - 30 * 24 * 60 * 60 * 1000);
+    const keySummary = {
+      total: allApiKeys.length,
+      recently_used: allApiKeys.filter((k) => k.last_used && new Date(k.last_used) >= thirtyDaysAgo).length,
+      never_used: allApiKeys.filter((k) => !k.last_used).length,
+    };
+
+    const eventsByType = recentEvents.reduce<Record<string, number>>((acc, e) => {
+      acc[e.event_type] = (acc[e.event_type] || 0) + 1;
+      return acc;
+    }, {});
+
+    return NextResponse.json({
+      trade_by_status: tradeByStatus,
+      listing_funnel: listingFunnel,
+      api_key_summary: keySummary,
+      analytics_events_7d: {
+        total: recentEvents.length,
+        by_type: eventsByType,
+      },
+    });
+  } catch (error) {
+    console.error('Analytics summary error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import TradesTab from '@/components/dashboard/TradesTab';
 import ApiKeysTab from '@/components/dashboard/ApiKeysTab';
 import WebhooksTab from '@/components/dashboard/WebhooksTab';
 import WalletTab from '@/components/dashboard/WalletTab';
+import AnalyticsTab from '@/components/dashboard/AnalyticsTab';
 
 interface User {
   id: string;
@@ -20,12 +21,13 @@ interface User {
 export default function DashboardPage() {
   const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
-  const [activeTab, setActiveTab] = useState<'listings' | 'trades' | 'api-keys' | 'webhooks' | 'wallet'>('listings');
+  const [activeTab, setActiveTab] = useState<'listings' | 'trades' | 'api-keys' | 'webhooks' | 'wallet' | 'analytics'>('listings');
   const [listings, setListings] = useState([]);
   const [trades, setTrades] = useState([]);
   const [apiKeys, setApiKeys] = useState([]);
   const [webhooksData, setWebhooksData] = useState([]);
   const [wallet, setWallet] = useState(null);
+  const [analytics, setAnalytics] = useState(null);
   const [loading, setLoading] = useState(true);
 
   const getCsrfToken = () =>
@@ -33,12 +35,13 @@ export default function DashboardPage() {
 
   const fetchData = useCallback(async () => {
     try {
-      const [listingsRes, tradesRes, apiKeysRes, webhooksRes, walletRes] = await Promise.all([
+      const [listingsRes, tradesRes, apiKeysRes, webhooksRes, walletRes, analyticsRes] = await Promise.all([
         fetch('/api/listings?seller=me', { credentials: 'include' }),
         fetch('/api/trades', { credentials: 'include' }),
         fetch('/api/auth/api-keys', { credentials: 'include' }),
         fetch('/api/webhooks', { credentials: 'include' }),
         fetch('/api/wallet', { credentials: 'include' }),
+        fetch('/api/analytics/summary', { credentials: 'include' }),
       ]);
 
       if (listingsRes.ok) { const d = await listingsRes.json(); setListings(d.listings || []); }
@@ -46,6 +49,7 @@ export default function DashboardPage() {
       if (apiKeysRes.ok) { const d = await apiKeysRes.json(); setApiKeys(d.keys || []); }
       if (webhooksRes.ok) { const d = await webhooksRes.json(); setWebhooksData(d.webhooks || []); }
       if (walletRes.ok) { const d = await walletRes.json(); setWallet(d); }
+      if (analyticsRes.ok) { const d = await analyticsRes.json(); setAnalytics(d); }
     } catch (error) {
       console.error('Failed to fetch data:', error);
     } finally {
@@ -84,6 +88,7 @@ export default function DashboardPage() {
     { id: 'listings' as const, label: 'My Listings', icon: '📋' },
     { id: 'trades' as const, label: 'Trade History', icon: '🤝' },
     { id: 'wallet' as const, label: 'Wallet', icon: '💳' },
+    { id: 'analytics' as const, label: 'Analytics', icon: '📊' },
     { id: 'api-keys' as const, label: 'API Keys', icon: '🔑' },
     { id: 'webhooks' as const, label: 'Webhooks', icon: '🔔' },
   ];
@@ -163,6 +168,9 @@ export default function DashboardPage() {
         )}
         {activeTab === 'wallet' && (
           <WalletTab wallet={wallet} loading={loading} />
+        )}
+        {activeTab === 'analytics' && (
+          <AnalyticsTab analytics={analytics} loading={loading} />
         )}
         {activeTab === 'api-keys' && (
           <ApiKeysTab apiKeys={apiKeys} loading={loading} onRefresh={fetchData} getCsrfToken={getCsrfToken} />

--- a/components/dashboard/AnalyticsTab.tsx
+++ b/components/dashboard/AnalyticsTab.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+interface AnalyticsSummary {
+  trade_by_status: { pending: number; completed: number; disputed: number };
+  listing_funnel: { active: number; sold: number; expired: number; total: number };
+  api_key_summary: { total: number; recently_used: number; never_used: number };
+  analytics_events_7d: { total: number; by_type: Record<string, number> };
+}
+
+interface AnalyticsTabProps {
+  analytics: AnalyticsSummary | null;
+  loading: boolean;
+}
+
+function Bar({ label, value, max, color }: { label: string; value: number; max: number; color: string }) {
+  const pct = max > 0 ? Math.round((value / max) * 100) : 0;
+  return (
+    <div>
+      <div className="flex justify-between text-xs text-text-dim mb-1">
+        <span>{label}</span>
+        <span>{value}</span>
+      </div>
+      <div className="h-2 bg-bg rounded-full overflow-hidden">
+        <div className={`h-full ${color}`} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export default function AnalyticsTab({ analytics, loading }: AnalyticsTabProps) {
+  if (loading) {
+    return (
+      <div className="grid md:grid-cols-3 gap-6 animate-pulse">
+        <div className="h-40 bg-surface rounded-xl" />
+        <div className="h-40 bg-surface rounded-xl" />
+        <div className="h-40 bg-surface rounded-xl" />
+      </div>
+    );
+  }
+
+  if (!analytics) {
+    return <div className="text-center py-12 text-text-dim">Failed to load analytics data.</div>;
+  }
+
+  const tradeMax = Math.max(
+    analytics.trade_by_status.pending,
+    analytics.trade_by_status.completed,
+    analytics.trade_by_status.disputed,
+    1
+  );
+
+  const listingMax = Math.max(
+    analytics.listing_funnel.active,
+    analytics.listing_funnel.sold,
+    analytics.listing_funnel.expired,
+    1
+  );
+
+  const topEvents = Object.entries(analytics.analytics_events_7d.by_type)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5);
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-6">Operator Analytics</h2>
+
+      <div className="grid md:grid-cols-3 gap-6 mb-8">
+        <div className="card">
+          <div className="text-xs uppercase text-text-dim mb-2">API Keys</div>
+          <div className="text-3xl font-bold">{analytics.api_key_summary.total}</div>
+          <div className="text-sm text-text-dim mt-2">
+            {analytics.api_key_summary.recently_used} used in last 30d · {analytics.api_key_summary.never_used} never used
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="text-xs uppercase text-text-dim mb-2">Listings</div>
+          <div className="text-3xl font-bold">{analytics.listing_funnel.total}</div>
+          <div className="text-sm text-text-dim mt-2">
+            {analytics.listing_funnel.sold} sold · {analytics.listing_funnel.active} active · {analytics.listing_funnel.expired} expired
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="text-xs uppercase text-text-dim mb-2">Events (7d)</div>
+          <div className="text-3xl font-bold">{analytics.analytics_events_7d.total}</div>
+          <div className="text-sm text-text-dim mt-2">Tracked behavior events in past 7 days</div>
+        </div>
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="card">
+          <h3 className="font-semibold mb-4">Trade Volume by Status</h3>
+          <div className="space-y-3">
+            <Bar label="Completed" value={analytics.trade_by_status.completed} max={tradeMax} color="bg-green-500" />
+            <Bar label="Pending" value={analytics.trade_by_status.pending} max={tradeMax} color="bg-yellow-500" />
+            <Bar label="Disputed" value={analytics.trade_by_status.disputed} max={tradeMax} color="bg-red-500" />
+          </div>
+        </div>
+
+        <div className="card">
+          <h3 className="font-semibold mb-4">Listing Conversion Funnel</h3>
+          <div className="space-y-3 mb-6">
+            <Bar label="Sold" value={analytics.listing_funnel.sold} max={listingMax} color="bg-accent" />
+            <Bar label="Active" value={analytics.listing_funnel.active} max={listingMax} color="bg-blue-500" />
+            <Bar label="Expired" value={analytics.listing_funnel.expired} max={listingMax} color="bg-gray-500" />
+          </div>
+
+          <h4 className="text-sm font-semibold text-text-dim uppercase">Top events (7d)</h4>
+          <div className="mt-2 space-y-1 text-sm">
+            {topEvents.length === 0 ? (
+              <div className="text-text-dim">No event data yet.</div>
+            ) : (
+              topEvents.map(([event, count]) => (
+                <div key={event} className="flex justify-between">
+                  <span className="text-text-dim">{event}</span>
+                  <span className="font-mono">{count}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -44,6 +44,9 @@ test.describe('Core smoke matrix', () => {
     await page.getByRole('button', { name: /Webhooks/ }).click();
     await expect(page.getByRole('heading', { name: 'Webhooks' })).toBeVisible();
 
+    await page.getByRole('button', { name: /Analytics/ }).click();
+    await expect(page.getByRole('heading', { name: 'Operator Analytics' })).toBeVisible();
+
     const csrf = await page.evaluate(() =>
       document.cookie.split('; ').find((r) => r.startsWith('csrf-token='))?.split('=')[1] || ''
     );


### PR DESCRIPTION
## What
Implements issue #5 by adding an authenticated operator analytics view in Dashboard.

### Added
- New API endpoint: /api/analytics/summary
  - trade volume by status (pending/completed/disputed)
  - listing funnel (active/sold/expired/total)
  - API key usage summary (total/recently used/never used)
  - analytics event totals by type (7d)
- New dashboard tab/component: AnalyticsTab
  - KPI cards + bar visualizations
  - empty/error/loading states
- Dashboard integration
  - new Analytics tab in tab bar
  - data fetch wired into dashboard load cycle
- E2E smoke update
  - verifies Analytics tab renders (Operator Analytics)

## Validation
- npm run build
- npm run test:e2e (8 passed)
