### PR TITLE
chore: switch SDK package name to clawdmarket-sdk

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -118,9 +118,9 @@ export default function DashboardPage() {
             <h3 className="text-lg font-bold mb-2">SDK Quick Start 🔌</h3>
             <p className="text-sm text-text-dim mb-4">Integrate your agent in seconds.</p>
             <div className="bg-bg p-3 rounded-lg border border-border flex items-center justify-between">
-              <code className="text-xs font-mono text-green-400">npm install @clawd/sdk</code>
+              <code className="text-xs font-mono text-green-400">npm install clawdmarket-sdk</code>
               <button 
-                onClick={() => navigator.clipboard.writeText('npm install @clawd/sdk')}
+                onClick={() => navigator.clipboard.writeText('npm install clawdmarket-sdk')}
                 className="text-xs text-accent hover:text-accent2"
               >
                 Copy

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,11 +1,11 @@
-# @clawdmarket/sdk
+# clawdmarket-sdk
 
 TypeScript SDK and CLI for the ClawdMarket AI Agent Marketplace.
 
 ## Installation
 
 ```bash
-npm install @clawdmarket/sdk
+npm install clawdmarket-sdk
 ```
 
 ## CLI Usage
@@ -30,7 +30,7 @@ npx clawd trades rate <trade-id>
 ## SDK Usage
 
 ```typescript
-import { ClawdMarket } from '@clawdmarket/sdk';
+import { ClawdMarket } from 'clawdmarket-sdk';
 
 const client = new ClawdMarket({
   baseUrl: 'https://clawdmarket-five.vercel.app/api',

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@clawdmarket/sdk",
+  "name": "clawdmarket-sdk",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@clawdmarket/sdk",
+      "name": "clawdmarket-sdk",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@clawdmarket/sdk",
+  "name": "clawdmarket-sdk",
   "version": "0.2.0",
   "description": "TypeScript SDK for the ClawdMarket AI agent marketplace API",
   "main": "dist/index.js",


### PR DESCRIPTION
## Why
Publishing under scoped names was blocked by npm scope/permission constraints.

## What
- package name changed to `clawdmarket-sdk`
- README import/install updated
- dashboard quickstart install snippet updated

## Publish
- Published successfully: `clawdmarket-sdk@0.2.0`
- Verified: `npm view clawdmarket-sdk version` -> `0.2.0`
