### PR TITLE
ops: add CI failure alerts for e2e and production smoke

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,7 @@ jobs:
       TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
       JWT_SECRET: ${{ secrets.JWT_SECRET != '' && secrets.JWT_SECRET || 'ci-jwt-secret-please-change' }}
       NEXT_PUBLIC_API_URL: http://localhost:3000
+      ALERT_WEBHOOK_URL: ${{ secrets.ALERT_WEBHOOK_URL }}
 
     steps:
       - name: Checkout
@@ -62,3 +63,14 @@ jobs:
             playwright-report/
             test-results/
           if-no-files-found: ignore
+
+      - name: Notify on failure
+        if: failure() && env.ALERT_WEBHOOK_URL != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MSG="🚨 E2E failed on ${{ github.repository }} (${{ github.ref_name }}). Run: $RUN_URL"
+          curl -sS -X POST "$ALERT_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"$MSG\",\"content\":\"$MSG\"}" >/dev/null

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -18,6 +18,7 @@ jobs:
       BASE_URL: ${{ inputs.base_url != '' && inputs.base_url || (secrets.PROD_BASE_URL != '' && secrets.PROD_BASE_URL || 'https://clawdmarket-five.vercel.app') }}
       SMOKE_EMAIL: ${{ secrets.SMOKE_EMAIL }}
       SMOKE_PASSWORD: ${{ secrets.SMOKE_PASSWORD }}
+      ALERT_WEBHOOK_URL: ${{ secrets.ALERT_WEBHOOK_URL }}
 
     steps:
       - name: Run production smoke checks
@@ -106,3 +107,14 @@ jobs:
             echo "- ✅ Listing create/delete"
             echo "- ✅ Trades list"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify on failure
+        if: failure() && env.ALERT_WEBHOOK_URL != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MSG="🚨 Production Smoke failed on ${{ github.repository }} (${{ github.ref_name }}). Run: $RUN_URL"
+          curl -sS -X POST "$ALERT_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"$MSG\",\"content\":\"$MSG\"}" >/dev/null


### PR DESCRIPTION
## What
Adds failure alerting for CI and post-deploy checks.

### Changes
- e2e workflow:
  - adds optional `ALERT_WEBHOOK_URL` env from GitHub secret
  - posts a failure alert message with run URL when job fails
- Production Smoke workflow:
  - adds optional `ALERT_WEBHOOK_URL` env from GitHub secret
  - posts a failure alert message with run URL when job fails

### Webhook compatibility
Payload includes both fields:
- `text` (Slack-style)
- `content` (Discord-style)

## Setup required
Add repository secret:
- `ALERT_WEBHOOK_URL`

If secret is not set, workflows behave as before (no alerts).
