### PR TITLE
feat: analytics v2 with range filters and event trend

### DIFF
--- a/app/api/analytics/summary/route.ts
+++ b/app/api/analytics/summary/route.ts
@@ -36,11 +36,14 @@ export async function GET(req: NextRequest) {
       db.select().from(api_keys),
     ]);
 
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const rangeParam = req.nextUrl.searchParams.get('range');
+    const rangeDays = rangeParam === '30' ? 30 : 7;
+
+    const rangeStart = new Date(Date.now() - rangeDays * 24 * 60 * 60 * 1000);
     const recentEvents = await db
       .select()
       .from(analytics_events)
-      .where(gte(analytics_events.created_at, sevenDaysAgo));
+      .where(gte(analytics_events.created_at, rangeStart));
 
     const tradeByStatus = {
       pending: allTrades.filter((t) => t.status === 'pending').length,
@@ -68,13 +71,29 @@ export async function GET(req: NextRequest) {
       return acc;
     }, {});
 
+    const trendBuckets: { date: string; count: number }[] = [];
+    for (let i = rangeDays - 1; i >= 0; i--) {
+      const d = new Date();
+      d.setHours(0, 0, 0, 0);
+      d.setDate(d.getDate() - i);
+      trendBuckets.push({ date: d.toISOString().slice(0, 10), count: 0 });
+    }
+
+    for (const ev of recentEvents) {
+      const key = new Date(ev.created_at).toISOString().slice(0, 10);
+      const bucket = trendBuckets.find((b) => b.date === key);
+      if (bucket) bucket.count += 1;
+    }
+
     return NextResponse.json({
+      range_days: rangeDays,
       trade_by_status: tradeByStatus,
       listing_funnel: listingFunnel,
       api_key_summary: keySummary,
-      analytics_events_7d: {
+      analytics_events: {
         total: recentEvents.length,
         by_type: eventsByType,
+        trend: trendBuckets,
       },
     });
   } catch (error) {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -28,6 +28,7 @@ export default function DashboardPage() {
   const [webhooksData, setWebhooksData] = useState([]);
   const [wallet, setWallet] = useState(null);
   const [analytics, setAnalytics] = useState(null);
+  const [analyticsRange, setAnalyticsRange] = useState<7 | 30>(7);
   const [loading, setLoading] = useState(true);
 
   const getCsrfToken = () =>
@@ -41,7 +42,7 @@ export default function DashboardPage() {
         fetch('/api/auth/api-keys', { credentials: 'include' }),
         fetch('/api/webhooks', { credentials: 'include' }),
         fetch('/api/wallet', { credentials: 'include' }),
-        fetch('/api/analytics/summary', { credentials: 'include' }),
+        fetch(`/api/analytics/summary?range=${analyticsRange}`, { credentials: 'include' }),
       ]);
 
       if (listingsRes.ok) { const d = await listingsRes.json(); setListings(d.listings || []); }
@@ -55,7 +56,7 @@ export default function DashboardPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [analyticsRange]);
 
   const checkAuthAndFetch = useCallback(async () => {
     try {
@@ -170,7 +171,12 @@ export default function DashboardPage() {
           <WalletTab wallet={wallet} loading={loading} />
         )}
         {activeTab === 'analytics' && (
-          <AnalyticsTab analytics={analytics} loading={loading} />
+          <AnalyticsTab
+            analytics={analytics}
+            loading={loading}
+            rangeDays={analyticsRange}
+            onRangeChange={setAnalyticsRange}
+          />
         )}
         {activeTab === 'api-keys' && (
           <ApiKeysTab apiKeys={apiKeys} loading={loading} onRefresh={fetchData} getCsrfToken={getCsrfToken} />

--- a/components/dashboard/AnalyticsTab.tsx
+++ b/components/dashboard/AnalyticsTab.tsx
@@ -1,15 +1,22 @@
 'use client';
 
 interface AnalyticsSummary {
+  range_days: 7 | 30;
   trade_by_status: { pending: number; completed: number; disputed: number };
   listing_funnel: { active: number; sold: number; expired: number; total: number };
   api_key_summary: { total: number; recently_used: number; never_used: number };
-  analytics_events_7d: { total: number; by_type: Record<string, number> };
+  analytics_events: {
+    total: number;
+    by_type: Record<string, number>;
+    trend: { date: string; count: number }[];
+  };
 }
 
 interface AnalyticsTabProps {
   analytics: AnalyticsSummary | null;
   loading: boolean;
+  rangeDays: 7 | 30;
+  onRangeChange: (days: 7 | 30) => void;
 }
 
 function Bar({ label, value, max, color }: { label: string; value: number; max: number; color: string }) {
@@ -27,7 +34,7 @@ function Bar({ label, value, max, color }: { label: string; value: number; max: 
   );
 }
 
-export default function AnalyticsTab({ analytics, loading }: AnalyticsTabProps) {
+export default function AnalyticsTab({ analytics, loading, rangeDays, onRangeChange }: AnalyticsTabProps) {
   if (loading) {
     return (
       <div className="grid md:grid-cols-3 gap-6 animate-pulse">
@@ -56,13 +63,31 @@ export default function AnalyticsTab({ analytics, loading }: AnalyticsTabProps) 
     1
   );
 
-  const topEvents = Object.entries(analytics.analytics_events_7d.by_type)
+  const topEvents = Object.entries(analytics.analytics_events.by_type)
     .sort((a, b) => b[1] - a[1])
     .slice(0, 5);
 
+  const trendMax = Math.max(...analytics.analytics_events.trend.map((d) => d.count), 1);
+
   return (
     <div>
-      <h2 className="text-2xl font-bold mb-6">Operator Analytics</h2>
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-2xl font-bold">Operator Analytics</h2>
+        <div className="flex gap-2">
+          <button
+            onClick={() => onRangeChange(7)}
+            className={`px-3 py-1 rounded text-sm ${rangeDays === 7 ? 'bg-accent text-black' : 'bg-surface text-text-dim'}`}
+          >
+            7d
+          </button>
+          <button
+            onClick={() => onRangeChange(30)}
+            className={`px-3 py-1 rounded text-sm ${rangeDays === 30 ? 'bg-accent text-black' : 'bg-surface text-text-dim'}`}
+          >
+            30d
+          </button>
+        </div>
+      </div>
 
       <div className="grid md:grid-cols-3 gap-6 mb-8">
         <div className="card">
@@ -82,9 +107,9 @@ export default function AnalyticsTab({ analytics, loading }: AnalyticsTabProps) 
         </div>
 
         <div className="card">
-          <div className="text-xs uppercase text-text-dim mb-2">Events (7d)</div>
-          <div className="text-3xl font-bold">{analytics.analytics_events_7d.total}</div>
-          <div className="text-sm text-text-dim mt-2">Tracked behavior events in past 7 days</div>
+          <div className="text-xs uppercase text-text-dim mb-2">Events ({rangeDays}d)</div>
+          <div className="text-3xl font-bold">{analytics.analytics_events.total}</div>
+          <div className="text-sm text-text-dim mt-2">Tracked behavior events in past {rangeDays} days</div>
         </div>
       </div>
 
@@ -106,7 +131,16 @@ export default function AnalyticsTab({ analytics, loading }: AnalyticsTabProps) 
             <Bar label="Expired" value={analytics.listing_funnel.expired} max={listingMax} color="bg-gray-500" />
           </div>
 
-          <h4 className="text-sm font-semibold text-text-dim uppercase">Top events (7d)</h4>
+          <h4 className="text-sm font-semibold text-text-dim uppercase">Event trend ({rangeDays}d)</h4>
+          <div className="mt-2 grid grid-cols-10 gap-1 items-end h-16">
+            {analytics.analytics_events.trend.slice(-10).map((point) => (
+              <div key={point.date} className="bg-bg rounded-sm relative group" style={{ height: `${Math.max(8, Math.round((point.count / trendMax) * 100))}%` }}>
+                <span className="hidden group-hover:block absolute -top-6 left-1/2 -translate-x-1/2 text-[10px] bg-black px-1 py-0.5 rounded">{point.count}</span>
+              </div>
+            ))}
+          </div>
+
+          <h4 className="text-sm font-semibold text-text-dim uppercase mt-6">Top events ({rangeDays}d)</h4>
           <div className="mt-2 space-y-1 text-sm">
             {topEvents.length === 0 ? (
               <div className="text-text-dim">No event data yet.</div>


### PR DESCRIPTION
## What
Analytics v2 upgrade for operator dashboard:
- add 7d/30d range filter
- return range-aware analytics from API
- include daily event trend series for selected range
- render mini trend bars in dashboard

## API changes
- /api/analytics/summary?range=7|30
- response now includes:
  - range_days
  - analytics_events.total
  - analytics_events.by_type
  - analytics_events.trend[]

## Validation
- npm run build
- npm run test:e2e (8 passed)
