### PR TITLE
hotfix: always surface wallet login popup for BANKR buy flow

### DIFF
--- a/app/marketplace/[id]/page.tsx
+++ b/app/marketplace/[id]/page.tsx
@@ -44,6 +44,7 @@ export default function ListingDetailPage() {
   const [tradeLoading, setTradeLoading] = useState(false);
   const [notFound, setNotFound] = useState(false);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [currentUserWallet, setCurrentUserWallet] = useState<string | null>(null);
   const [sellerProfile, setSellerProfile] = useState<SellerTrustProfile | null>(null);
   const [isFavorite, setIsFavorite] = useState(false);
   const [favoriteLoading, setFavoriteLoading] = useState(false);
@@ -59,6 +60,7 @@ export default function ListingDetailPage() {
       if (res.ok) {
         const data = await res.json();
         setCurrentUserId(data.user.id);
+        setCurrentUserWallet(data.user.wallet || null);
 
         const watchlistRes = await fetch('/api/watchlist', { credentials: 'include' });
         if (watchlistRes.ok && params.id) {
@@ -147,9 +149,9 @@ export default function ListingDetailPage() {
   const handleTrade = async () => {
     if (!listing) return;
 
-    if (!currentUserId) {
+    if (!currentUserId || !currentUserWallet) {
       setShowWalletLogin(true);
-      toast('Connect your wallet to buy with BANKR', 'error');
+      toast('Connect your crypto wallet to buy with BANKR', 'error');
       return;
     }
 
@@ -412,7 +414,17 @@ export default function ListingDetailPage() {
             </div>
           </div>
         </div>
-        {showWalletLogin && <WalletLoginPopup />}
+        {showWalletLogin && (
+          <WalletLoginPopup
+            forceShow
+            redirectToDashboard={false}
+            onAuthenticated={async () => {
+              setShowWalletLogin(false);
+              await fetchMe();
+              toast('Wallet connected. You can complete your BANKR purchase now.', 'success');
+            }}
+          />
+        )}
       </div>
     </PageShell>
   );

--- a/components/WalletLoginPopup.tsx
+++ b/components/WalletLoginPopup.tsx
@@ -5,7 +5,17 @@ import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
-export default function WalletLoginPopup() {
+interface WalletLoginPopupProps {
+  forceShow?: boolean;
+  redirectToDashboard?: boolean;
+  onAuthenticated?: () => void;
+}
+
+export default function WalletLoginPopup({
+  forceShow = false,
+  redirectToDashboard = true,
+  onAuthenticated,
+}: WalletLoginPopupProps) {
   const router = useRouter();
   const { address, isConnected } = useAccount();
   const { disconnect } = useDisconnect();
@@ -17,12 +27,17 @@ export default function WalletLoginPopup() {
 
   // Check if user is already logged in
   useEffect(() => {
+    if (forceShow) {
+      setShouldShow(true);
+      return;
+    }
+
     fetch('/api/auth/me')
       .then(res => {
         if (!res.ok) setShouldShow(true);
       })
       .catch(() => setShouldShow(true));
-  }, []);
+  }, [forceShow]);
 
   const completeWalletLogin = useCallback(async () => {
     if (!address || !isConnected) return;
@@ -57,7 +72,10 @@ export default function WalletLoginPopup() {
 
       setStatus('done');
       setTimeout(() => {
-        router.push('/dashboard');
+        onAuthenticated?.();
+        if (redirectToDashboard) {
+          router.push('/dashboard');
+        }
       }, 500);
     } catch (err: any) {
       setStatus('error');
@@ -65,7 +83,7 @@ export default function WalletLoginPopup() {
       // Disconnect on failure so user can retry cleanly
       disconnect();
     }
-  }, [address, isConnected, signMessageAsync, router, disconnect]);
+  }, [address, isConnected, signMessageAsync, router, disconnect, onAuthenticated, redirectToDashboard]);
 
   useEffect(() => {
     if (isConnected && address && status === 'idle') {


### PR DESCRIPTION
Fixes missing wallet popup during buy flow.\n\n- Adds force-show option for WalletLoginPopup\n- Listing buy now checks both auth session and connected wallet\n- On missing wallet/auth, popup is shown inline on listing page\n- On wallet auth success, page refreshes user state and prompts to complete purchase\n- Keeps CSRF credentials/header handling in trade POST\n\nValidation: npm run build