### PR TITLE
feat: secure admin BANKR fee wallet routing

### DIFF
--- a/app/api/trades/[id]/route.ts
+++ b/app/api/trades/[id]/route.ts
@@ -5,7 +5,7 @@ import { authenticateRequest } from '@/lib/auth';
 import { updateTradeStatusSchema, isValidUUID } from '@/lib/validation';
 import { validateCsrf } from '@/lib/csrf';
 import { fireWebhook } from '@/lib/webhooks';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { envMeta } from '@/lib/agent-environment';
 import { validateAgentInstruction } from '@/lib/agent-security';
 
@@ -95,27 +95,43 @@ export async function PATCH(
 
       // 2. Handle funds if completing
       if (validated.status === 'completed') {
-        // Release from Buyer's Escrow (decrement escrow)
-        await tx
-          .update(wallets)
-          .set({ escrow: sql`${wallets.escrow} - ${trade.amount}` })
-          .where(eq(wallets.user_id, trade.buyer_id));
+        const [escrowLockTx] = await tx
+          .select()
+          .from(transactions)
+          .where(and(eq(transactions.reference_id, trade.id), eq(transactions.type, 'escrow_lock')))
+          .limit(1);
 
-        // Credit Seller's Balance
-        await tx
-          .update(wallets)
-          .set({ balance: sql`${wallets.balance} + ${trade.amount}` })
-          .where(eq(wallets.user_id, trade.seller_id));
+        if (escrowLockTx) {
+          // Legacy internal-ledger settlement path
+          await tx
+            .update(wallets)
+            .set({ escrow: sql`${wallets.escrow} - ${trade.amount}` })
+            .where(eq(wallets.user_id, trade.buyer_id));
 
-        // Log transaction
-        await tx.insert(transactions).values({
-          from_user_id: trade.buyer_id,
-          to_user_id: trade.seller_id,
-          amount: trade.amount,
-          type: 'escrow_release',
-          reference_id: trade.id,
-          memo: 'Trade completed',
-        });
+          await tx
+            .update(wallets)
+            .set({ balance: sql`${wallets.balance} + ${trade.amount}` })
+            .where(eq(wallets.user_id, trade.seller_id));
+
+          await tx.insert(transactions).values({
+            from_user_id: trade.buyer_id,
+            to_user_id: trade.seller_id,
+            amount: trade.amount,
+            type: 'escrow_release',
+            reference_id: trade.id,
+            memo: 'Trade completed',
+          });
+        } else {
+          // On-chain settlement path: funds already moved on-chain at purchase time.
+          await tx.insert(transactions).values({
+            from_user_id: trade.buyer_id,
+            to_user_id: trade.seller_id,
+            amount: trade.amount,
+            type: 'transfer',
+            reference_id: trade.id,
+            memo: 'Trade completed (on-chain settlement already recorded)',
+          });
+        }
       } else if (validated.status === 'disputed') {
         // For disputes, funds stay in escrow until admin resolution (manual for now)
         // Or we could auto-refund, but 'dispute' usually means freeze.

--- a/app/api/trades/route.ts
+++ b/app/api/trades/route.ts
@@ -12,6 +12,8 @@ import { isAddress } from 'viem';
 import { envMeta } from '@/lib/agent-environment';
 import { validateAgentInstruction } from '@/lib/agent-security';
 
+const TX_HASH_RE = /^0x([A-Fa-f0-9]{64})$/;
+
 const ECOSYSTEM_FEE_PERCENT = 0.03; // 3% fee
 
 async function ensureAdminFeeRecipient(): Promise<string | null> {
@@ -132,8 +134,116 @@ export async function POST(req: NextRequest) {
     const fee = validated.amount * ECOSYSTEM_FEE_PERCENT;
     const totalCost = validated.amount + fee;
 
-    // ─── ESCROW LOGIC START ───
-    
+    const bodyPaymentMode = (body?.payment_mode || '').toString();
+    const onchain = body?.onchain || null;
+
+    if (bodyPaymentMode === 'onchain') {
+      const expectedToken = (process.env.BANKR_TOKEN_ADDRESS || '').toLowerCase();
+      const expectedEscrow = (process.env.ESCROW_WALLET_ADDRESS || '').toLowerCase();
+      const expectedFeeWallet = (process.env.DEV_FEE_WALLET_ADDRESS || '').toLowerCase();
+
+      if (!expectedToken || !expectedEscrow || !expectedFeeWallet) {
+        return NextResponse.json(
+          { error: 'On-chain payment is not configured on server' },
+          { status: 500 }
+        );
+      }
+
+      if (!onchain || onchain.chain !== 'base') {
+        return NextResponse.json({ error: 'Invalid on-chain payment payload (chain)' }, { status: 400 });
+      }
+
+      if (
+        String(onchain.token_address || '').toLowerCase() !== expectedToken ||
+        String(onchain.escrow_wallet || '').toLowerCase() !== expectedEscrow ||
+        String(onchain.fee_wallet || '').toLowerCase() !== expectedFeeWallet
+      ) {
+        return NextResponse.json({ error: 'On-chain payment destination mismatch' }, { status: 400 });
+      }
+
+      if (!TX_HASH_RE.test(String(onchain.escrow_tx_hash || '')) || !TX_HASH_RE.test(String(onchain.fee_tx_hash || ''))) {
+        return NextResponse.json({ error: 'Invalid on-chain transaction hash format' }, { status: 400 });
+      }
+
+      const adminFeeRecipientUserId = await ensureAdminFeeRecipient();
+
+      const newTrade = await db.transaction(async (tx) => {
+        const [trade] = await tx
+          .insert(trades)
+          .values({
+            listing_id: validated.listing_id,
+            buyer_id: auth.userId,
+            seller_id: listing.seller_id,
+            amount: validated.amount,
+            fee,
+            status: 'pending',
+          })
+          .returning();
+
+        await tx.update(listings).set({ status: 'sold' }).where(eq(listings.id, validated.listing_id));
+
+        await tx.insert(transactions).values({
+          from_user_id: auth.userId,
+          to_user_id: null,
+          amount: validated.amount,
+          type: 'transfer',
+          reference_id: trade.id,
+          memo: `On-chain escrow transfer (${onchain.escrow_tx_hash})`,
+        });
+
+        if (fee > 0) {
+          if (adminFeeRecipientUserId) {
+            await tx
+              .update(wallets)
+              .set({ balance: sql`${wallets.balance} + ${fee}` })
+              .where(eq(wallets.user_id, adminFeeRecipientUserId));
+          }
+
+          await tx.insert(transactions).values({
+            from_user_id: auth.userId,
+            to_user_id: adminFeeRecipientUserId,
+            amount: fee,
+            type: 'fee',
+            reference_id: trade.id,
+            memo: `On-chain fee transfer (${onchain.fee_tx_hash})`,
+          });
+        }
+
+        return trade;
+      });
+
+      Promise.all([
+        fireWebhook(auth.userId, 'trade.created', { trade: newTrade }),
+        fireWebhook(listing.seller_id, 'trade.created', { trade: newTrade }),
+        fireWebhook(listing.seller_id, 'listing.sold', { listing_id: validated.listing_id, trade: newTrade }),
+      ]).catch(err => console.error('Webhook error:', err));
+
+      return NextResponse.json(
+        {
+          message: 'Trade initiated successfully with on-chain BANKR payment.',
+          trade: newTrade,
+          code: 'TRADE_CREATED_ONCHAIN',
+          fee_info: {
+            amount: validated.amount,
+            ecosystem_fee: fee,
+            seller_receives: validated.amount,
+            admin_fee_wallet_configured: Boolean(process.env.ADMIN_BANKR_WALLET_ADDRESS),
+          },
+          onchain_receipts: {
+            escrow_tx_hash: onchain.escrow_tx_hash,
+            fee_tx_hash: onchain.fee_tx_hash,
+          },
+          ...envMeta('clawdmarket/api/trades'),
+        },
+        {
+          status: 201,
+          headers: getRateLimitHeaders(rateLimitResult),
+        }
+      );
+    }
+
+    // ─── LEDGER ESCROW LOGIC (legacy fallback) ───
+
     // 1. Check buyer balance
     const [buyerWallet] = await db
       .select()

--- a/app/marketplace/[id]/page.tsx
+++ b/app/marketplace/[id]/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import { useAccount, usePublicClient, useWriteContract } from 'wagmi';
+import { erc20Abi, parseUnits } from 'viem';
 import { useParams, useRouter } from 'next/navigation';
 import PageShell from '@/components/PageShell';
 import { SkeletonDetail } from '@/components/Skeleton';
@@ -50,6 +52,9 @@ export default function ListingDetailPage() {
   const [favoriteLoading, setFavoriteLoading] = useState(false);
   const [showWalletLogin, setShowWalletLogin] = useState(false);
   const { track } = useAnalytics();
+  const { address: connectedAddress, isConnected } = useAccount();
+  const { writeContractAsync } = useWriteContract();
+  const publicClient = usePublicClient();
 
   const getCsrfToken = () =>
     document.cookie.split('; ').find(r => r.startsWith('csrf-token='))?.split('=')[1] || '';
@@ -149,16 +154,25 @@ export default function ListingDetailPage() {
   const handleTrade = async () => {
     if (!listing) return;
 
-    if (!currentUserId || !currentUserWallet) {
+    if (!currentUserId || !currentUserWallet || !isConnected || !connectedAddress) {
       setShowWalletLogin(true);
       toast('Connect your crypto wallet to buy with BANKR', 'error');
+      return;
+    }
+
+    const bankrToken = process.env.NEXT_PUBLIC_BANKR_TOKEN_ADDRESS;
+    const escrowWallet = process.env.NEXT_PUBLIC_ESCROW_WALLET_ADDRESS;
+    const devFeeWallet = process.env.NEXT_PUBLIC_DEV_FEE_WALLET_ADDRESS;
+
+    if (!bankrToken || !escrowWallet || !devFeeWallet) {
+      toast('On-chain payment configuration is missing. Contact admin.', 'error');
       return;
     }
 
     const fee = listing.price_bankr * 0.03;
     const total = listing.price_bankr + fee;
 
-    if (!confirm(`Are you sure you want to buy this item?\n\nPrice: ${listing.price_bankr} BANKR\nFee (3%): ${fee.toFixed(2)} BANKR\nTotal: ${total.toFixed(2)} BANKR\n\nFunds will be locked in escrow until you confirm receipt.`)) {
+    if (!confirm(`Are you sure you want to buy this item?\n\nPrice: ${listing.price_bankr} BANKR\nFee (3%): ${fee.toFixed(2)} BANKR\nTotal: ${total.toFixed(2)} BANKR\n\nYou will sign on-chain BANKR transfers for escrow and fee.`)) {
       return;
     }
 
@@ -166,6 +180,27 @@ export default function ListingDetailPage() {
     setTradeLoading(true);
 
     try {
+      const escrowAmount = parseUnits(listing.price_bankr.toFixed(18), 18);
+      const feeAmount = parseUnits(fee.toFixed(18), 18);
+
+      const escrowTxHash = await writeContractAsync({
+        address: bankrToken as `0x${string}`,
+        abi: erc20Abi,
+        functionName: 'transfer',
+        args: [escrowWallet as `0x${string}`, escrowAmount],
+      });
+
+      await publicClient?.waitForTransactionReceipt({ hash: escrowTxHash });
+
+      const feeTxHash = await writeContractAsync({
+        address: bankrToken as `0x${string}`,
+        abi: erc20Abi,
+        functionName: 'transfer',
+        args: [devFeeWallet as `0x${string}`, feeAmount],
+      });
+
+      await publicClient?.waitForTransactionReceipt({ hash: feeTxHash });
+
       const csrfToken = getCsrfToken();
       const res = await fetch('/api/trades', {
         method: 'POST',
@@ -177,27 +212,35 @@ export default function ListingDetailPage() {
         body: JSON.stringify({
           listing_id: listing.id,
           amount: listing.price_bankr,
+          payment_mode: 'onchain',
+          onchain: {
+            chain: 'base',
+            token_address: bankrToken,
+            buyer_wallet: connectedAddress,
+            escrow_wallet: escrowWallet,
+            fee_wallet: devFeeWallet,
+            escrow_tx_hash: escrowTxHash,
+            fee_tx_hash: feeTxHash,
+          },
         }),
       });
 
       const data = await res.json();
 
       if (res.ok) {
-        toast('Trade successful! Funds locked in escrow.', 'success');
+        toast('Trade successful! On-chain BANKR payment confirmed.', 'success');
         router.push('/dashboard');
       } else {
         if (res.status === 401 || res.status === 403) {
           setShowWalletLogin(true);
           toast('Please connect your wallet to continue', 'error');
-        } else if (res.status === 402) {
-          toast(`Insufficient funds. ${data.error}`, 'error');
         } else {
           toast(data.error || 'Trade failed', 'error');
         }
       }
-    } catch (err) {
+    } catch (err: any) {
       console.error(err);
-      toast('Network error. Please try again.', 'error');
+      toast(err?.shortMessage || err?.message || 'On-chain transaction failed', 'error');
     } finally {
       setTradeLoading(false);
     }


### PR DESCRIPTION
## Secure-mode BANKR on-chain trading (Base)

Implements direct on-chain BANKR payment path for purchases with escrow + dev-fee split.

### Added
- Frontend buy flow now executes BANKR ERC-20 transfers on-chain via connected wallet:
  - item amount -> escrow wallet
  - fee amount (3%) -> dev fee wallet
- Trade create API supports `payment_mode: onchain` with receipt hashes and validates server-configured destinations.
- On-chain trade creation records receipts and marks listing sold without relying on internal balance lock.
- Trade completion route now distinguishes legacy internal-ledger escrow from on-chain flow and avoids erroneous internal escrow release for on-chain trades.
- Secure admin fee routing:
  - `ADMIN_BANKR_WALLET_ADDRESS` resolved server-side
  - fee transactions credit configured admin wallet user safely (no private keys stored in DB/frontend)

### Config applied (production)
- CHAIN=base
- BANKR_TOKEN_ADDRESS=0x22af33fe49fd1fa80c7149773dde5890d3c76f3b
- NEXT_PUBLIC_BANKR_TOKEN_ADDRESS=0x22af33fe49fd1fa80c7149773dde5890d3c76f3b
- ESCROW_WALLET_ADDRESS=0x3E911a2EaFbE60ca538F659836d6DE60Db639D44
- NEXT_PUBLIC_ESCROW_WALLET_ADDRESS=0x3E911a2EaFbE60ca538F659836d6DE60Db639D44
- DEV_FEE_WALLET_ADDRESS=0x3324B8045c88c163eCf7a4C596610814cdF0dC8C
- NEXT_PUBLIC_DEV_FEE_WALLET_ADDRESS=0x3324B8045c88c163eCf7a4C596610814cdF0dC8C
- DEV_FEE_BPS=300
- ADMIN_BANKR_WALLET_ADDRESS=0x3324B8045c88c163eCf7a4C596610814cdF0dC8C

### Validation
- npm run build
