### PR TITLE
feat: add Other listing category (💨)

### DIFF
--- a/app/api/docs/route.ts
+++ b/app/api/docs/route.ts
@@ -42,7 +42,7 @@ const openApiSpec = {
         properties: {
           id: { type: 'string', format: 'uuid' },
           seller_id: { type: 'string', format: 'uuid' },
-          category: { type: 'string', enum: ['compute', 'skills', 'data', 'bounties'] },
+          category: { type: 'string', enum: ['compute', 'skills', 'data', 'bounties', 'other'] },
           title: { type: 'string' },
           description: { type: 'string' },
           price_bankr: { type: 'number', minimum: 864, maximum: 2465 },
@@ -314,7 +314,7 @@ const openApiSpec = {
       get: {
         summary: 'List marketplace listings',
         parameters: [
-          { name: 'category', in: 'query', schema: { type: 'string', enum: ['compute', 'skills', 'data', 'bounties'] } },
+          { name: 'category', in: 'query', schema: { type: 'string', enum: ['compute', 'skills', 'data', 'bounties', 'other'] } },
           { name: 'status', in: 'query', schema: { type: 'string', enum: ['active', 'sold', 'expired'] } },
           { name: 'page', in: 'query', schema: { type: 'integer', default: 1 } },
           { name: 'limit', in: 'query', schema: { type: 'integer', default: 20 } },
@@ -356,7 +356,7 @@ const openApiSpec = {
                     type: 'object',
                     required: ['category', 'title', 'description', 'price_bankr'],
                     properties: {
-                      category: { type: 'string', enum: ['compute', 'skills', 'data', 'bounties'] },
+                      category: { type: 'string', enum: ['compute', 'skills', 'data', 'bounties', 'other'] },
                       title: { type: 'string', minLength: 5, maxLength: 100 },
                       description: { type: 'string', minLength: 20, maxLength: 1000 },
                       price_bankr: { type: 'number', minimum: 864, maximum: 2465 },
@@ -369,7 +369,7 @@ const openApiSpec = {
                       type: 'object',
                       required: ['category', 'title', 'description', 'price_bankr'],
                       properties: {
-                        category: { type: 'string', enum: ['compute', 'skills', 'data', 'bounties'] },
+                        category: { type: 'string', enum: ['compute', 'skills', 'data', 'bounties', 'other'] },
                         title: { type: 'string', minLength: 5, maxLength: 100 },
                         description: { type: 'string', minLength: 20, maxLength: 1000 },
                         price_bankr: { type: 'number', minimum: 864, maximum: 2465 },
@@ -421,7 +421,7 @@ const openApiSpec = {
                   title: { type: 'string', minLength: 5, maxLength: 100 },
                   description: { type: 'string', minLength: 20, maxLength: 1000 },
                   price_bankr: { type: 'number', minimum: 864, maximum: 2465 },
-                  category: { type: 'string', enum: ['compute', 'skills', 'data', 'bounties'] },
+                  category: { type: 'string', enum: ['compute', 'skills', 'data', 'bounties', 'other'] },
                 },
               },
             },

--- a/app/api/listings/route.ts
+++ b/app/api/listings/route.ts
@@ -80,7 +80,7 @@ async function selectListings(whereClause: any, limit: number, offset: number) {
 
 async function insertListing(values: {
   seller_id: string;
-  category: 'compute' | 'skills' | 'data' | 'bounties';
+  category: 'compute' | 'skills' | 'data' | 'bounties' | 'other';
   title: string;
   description: string;
   price_bankr: number;

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -41,7 +41,7 @@ const endpoints = [
       { method: 'GET', path: '/api/listings', desc: 'Browse marketplace listings with filters', auth: false,
         params: 'category, status, page, limit, search, seller_id, min_price, max_price' },
       { method: 'POST', path: '/api/listings', desc: 'Create one or more listings', auth: true,
-        body: '{ "category": "compute|skills|data|bounties", "title": "string", "description": "string", "price_bankr": number (864-2465) }' },
+        body: '{ "category": "compute|skills|data|bounties|other", "title": "string", "description": "string", "price_bankr": number (864-2465) }' },
       { method: 'GET', path: '/api/listings/:id', desc: 'Get listing details by ID', auth: false },
       { method: 'PUT', path: '/api/listings/:id', desc: 'Update your listing', auth: true,
         body: '{ "title?": "string", "description?": "string", "price_bankr?": number (864-2465), "category?": "string" }' },

--- a/app/marketplace/[id]/page.tsx
+++ b/app/marketplace/[id]/page.tsx
@@ -247,7 +247,7 @@ export default function ListingDetailPage() {
   };
 
   const categoryIcons: Record<string, string> = {
-    compute: '⚡', skills: '🧩', data: '📊', bounties: '🎯',
+    compute: '⚡', skills: '🧩', data: '📊', bounties: '🎯', other: '💨',
   };
 
   if (loading) {

--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -176,6 +176,7 @@ export default function MarketplacePage() {
     { value: 'skills', label: 'Skills', icon: '🧩' },
     { value: 'data', label: 'Data', icon: '📊' },
     { value: 'bounties', label: 'Bounties', icon: '🎯' },
+    { value: 'other', label: 'Other', icon: '💨' },
   ];
 
   return (

--- a/components/ListingCard.tsx
+++ b/components/ListingCard.tsx
@@ -18,6 +18,7 @@ const categoryIcons: Record<string, string> = {
   skills: '🧩',
   data: '📊',
   bounties: '🎯',
+  other: '💨',
 };
 
 const categoryColors: Record<string, string> = {
@@ -25,6 +26,7 @@ const categoryColors: Record<string, string> = {
   skills: 'text-gold border-gold/30',
   data: 'text-green-400 border-green-400/30',
   bounties: 'text-blue-400 border-blue-400/30',
+  other: 'text-gray-300 border-gray-300/30',
 };
 
 export default function ListingCard({

--- a/components/dashboard/ListingsTab.tsx
+++ b/components/dashboard/ListingsTab.tsx
@@ -25,7 +25,7 @@ export default function ListingsTab({ listings, loading, onRefresh, getCsrfToken
   const { toast } = useToast();
   const [showCreate, setShowCreate] = useState(false);
   const [form, setForm] = useState({
-    category: 'compute' as 'compute' | 'skills' | 'data' | 'bounties',
+    category: 'compute' as 'compute' | 'skills' | 'data' | 'bounties' | 'other',
     title: '',
     description: '',
     price_bankr: '',
@@ -93,6 +93,7 @@ export default function ListingsTab({ listings, loading, onRefresh, getCsrfToken
                 <option value="skills">🧩 Skills</option>
                 <option value="data">📊 Data</option>
                 <option value="bounties">🎯 Bounties</option>
+                <option value="other">💨 Other</option>
               </select>
             </div>
             <div>

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -34,7 +34,7 @@ export const listings = sqliteTable('listings', {
     .notNull()
     .references(() => users.id, { onDelete: 'cascade' }),
   category: text('category', { 
-    enum: ['compute', 'skills', 'data', 'bounties'] 
+    enum: ['compute', 'skills', 'data', 'bounties', 'other'] 
   }).notNull(),
   title: text('title').notNull(),
   description: text('description').notNull(),

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -23,7 +23,7 @@ export const createApiKeySchema = z.object({
 });
 
 export const createListingSchema = z.object({
-  category: z.enum(['compute', 'skills', 'data', 'bounties']),
+  category: z.enum(['compute', 'skills', 'data', 'bounties', 'other']),
   title: z.string().min(5, 'Title must be at least 5 characters').max(100, 'Title too long'),
   description: z.string().min(20, 'Description must be at least 20 characters').max(1000, 'Description too long'),
   price_bankr: z.number().min(864, 'Price must be at least 864').max(2465, 'Price must be at most 2465'),
@@ -44,7 +44,7 @@ export const waitlistSchema = z.object({
 });
 
 export const listingsQuerySchema = z.object({
-  category: z.enum(['compute', 'skills', 'data', 'bounties']).optional(),
+  category: z.enum(['compute', 'skills', 'data', 'bounties', 'other']).optional(),
   status: z.enum(['active', 'sold', 'expired']).optional(),
   page: z.coerce.number().int().positive().optional().default(1),
   limit: z.coerce.number().int().positive().max(100).optional().default(20),
@@ -59,7 +59,7 @@ export const updateListingSchema = z.object({
   title: z.string().min(5, 'Title must be at least 5 characters').max(100, 'Title too long').optional(),
   description: z.string().min(20, 'Description must be at least 20 characters').max(1000, 'Description too long').optional(),
   price_bankr: z.number().min(864, 'Price must be at least 864').max(2465, 'Price must be at most 2465').optional(),
-  category: z.enum(['compute', 'skills', 'data', 'bounties']).optional(),
+  category: z.enum(['compute', 'skills', 'data', 'bounties', 'other']).optional(),
 });
 
 export const updateTradeStatusSchema = z.object({

--- a/sdk/dist/cli.js
+++ b/sdk/dist/cli.js
@@ -201,7 +201,7 @@ const listings = program.command('listings').description('Browse and manage list
 listings
     .command('list')
     .description('List available items on the marketplace')
-    .option('-c, --category <category>', 'Filter by category (compute, skills, data, bounties)')
+    .option('-c, --category <category>', 'Filter by category (compute, skills, data, bounties, other)')
     .option('-l, --limit <number>', 'Number of items to show', '10')
     .option('-s, --search <query>', 'Search term')
     .action(async (options) => {
@@ -262,7 +262,7 @@ listings
             type: 'list',
             name: 'category',
             message: 'Category:',
-            choices: ['compute', 'skills', 'data', 'bounties'],
+            choices: ['compute', 'skills', 'data', 'bounties', 'other'],
         },
         {
             type: 'input',

--- a/sdk/dist/index.d.ts
+++ b/sdk/dist/index.d.ts
@@ -7,7 +7,7 @@ export interface Listing {
     id: string;
     seller_id: string;
     seller_name: string;
-    category: 'compute' | 'skills' | 'data' | 'bounties';
+    category: 'compute' | 'skills' | 'data' | 'bounties' | 'other';
     title: string;
     description: string;
     price_bankr: number;
@@ -15,7 +15,7 @@ export interface Listing {
     created_at: string;
 }
 export interface ListingsQuery {
-    category?: 'compute' | 'skills' | 'data' | 'bounties';
+    category?: 'compute' | 'skills' | 'data' | 'bounties' | 'other';
     search?: string;
     limit?: number;
     page?: number;

--- a/sdk/dist/types.d.ts
+++ b/sdk/dist/types.d.ts
@@ -34,7 +34,7 @@ export interface CreateApiKeyResponse {
     };
     warning: string;
 }
-export type ListingCategory = 'compute' | 'skills' | 'data' | 'bounties';
+export type ListingCategory = 'compute' | 'skills' | 'data' | 'bounties' | 'other';
 export type ListingStatus = 'active' | 'sold' | 'expired';
 export interface Listing {
     id: string;

--- a/sdk/src/cli.ts
+++ b/sdk/src/cli.ts
@@ -224,7 +224,7 @@ const listings = program.command('listings').description('Browse and manage list
 listings
   .command('list')
   .description('List available items on the marketplace')
-  .option('-c, --category <category>', 'Filter by category (compute, skills, data, bounties)')
+  .option('-c, --category <category>', 'Filter by category (compute, skills, data, bounties, other)')
   .option('-l, --limit <number>', 'Number of items to show', '10')
   .option('-s, --search <query>', 'Search term')
   .action(async (options) => {
@@ -295,7 +295,7 @@ listings
         type: 'list',
         name: 'category',
         message: 'Category:',
-        choices: ['compute', 'skills', 'data', 'bounties'],
+        choices: ['compute', 'skills', 'data', 'bounties', 'other'],
       },
       {
         type: 'input',

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -18,7 +18,7 @@ export interface Listing {
   id: string;
   seller_id: string;
   seller_name: string;
-  category: 'compute' | 'skills' | 'data' | 'bounties';
+  category: 'compute' | 'skills' | 'data' | 'bounties' | 'other';
   title: string;
   description: string;
   price_bankr: number;
@@ -27,7 +27,7 @@ export interface Listing {
 }
 
 export interface ListingsQuery {
-  category?: 'compute' | 'skills' | 'data' | 'bounties';
+  category?: 'compute' | 'skills' | 'data' | 'bounties' | 'other';
   search?: string;
   limit?: number;
   page?: number;

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -44,7 +44,7 @@ export interface CreateApiKeyResponse {
 
 // ─── Listings ─────────────────────────────────────────────────────────────────
 
-export type ListingCategory = 'compute' | 'skills' | 'data' | 'bounties';
+export type ListingCategory = 'compute' | 'skills' | 'data' | 'bounties' | 'other';
 export type ListingStatus = 'active' | 'sold' | 'expired';
 
 export interface Listing {


### PR DESCRIPTION
Adds new listing category `other` with smoke icon 💨 across API, validation, UI, docs, and SDK.

- No listings are auto-populated for this category
- Users can create listings in `other`

Validation: npm run build && cd sdk && npm run build
