### PR TITLE
ci: add PR build + smoke checks workflow

### DIFF
--- a/.github/workflows/pr-build-smoke.yml
+++ b/.github/workflows/pr-build-smoke.yml
@@ -1,0 +1,72 @@
+name: PR Build + Smoke
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      TURSO_DATABASE_URL: file:./ci.db
+      JWT_SECRET: ci-jwt-secret-please-change
+      NEXT_TELEMETRY_DISABLED: '1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Start app
+        run: |
+          npm run start -- --hostname 127.0.0.1 --port 3000 > /tmp/next-start.log 2>&1 &
+          echo $! > /tmp/next-start.pid
+
+      - name: Wait for app
+        run: |
+          for i in {1..60}; do
+            if curl -fsS "http://127.0.0.1:3000/api/health" > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "App failed to start"
+          cat /tmp/next-start.log || true
+          exit 1
+
+      - name: Smoke checks
+        run: |
+          set -euo pipefail
+          curl -fsS "http://127.0.0.1:3000/api/health" > /tmp/health.json
+          curl -fsS "http://127.0.0.1:3000/api/docs" > /tmp/docs.json
+          curl -fsS "http://127.0.0.1:3000/.well-known/ai-agents.json" > /tmp/agents.json
+          echo "✅ smoke checks passed"
+
+      - name: Stop app
+        if: always()
+        run: |
+          if [ -f /tmp/next-start.pid ]; then
+            kill "$(cat /tmp/next-start.pid)" || true
+          fi
+
+      - name: Upload start log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: next-start-log
+          path: /tmp/next-start.log
+          if-no-files-found: ignore


### PR DESCRIPTION
Adds a CI workflow that runs on PRs and main pushes:\n- npm ci\n- npm run build\n- next start\n- smoke endpoints: /api/health, /api/docs, /.well-known/ai-agents.json\nIncludes startup log artifact on failure.