### PR TITLE
feat: MPP integration — agent payments, discovery, and session support

### DIFF
--- a/tests/api/mcp-route.test.ts
+++ b/tests/api/mcp-route.test.ts
@@ -83,3 +83,36 @@ test('tools/call unknown tool returns MCP tool error envelope', async () => {
   assert.equal(body.result?.isError, true);
   assert.match(body.result?.content?.[0]?.text || '', /^Error:/);
 });
+
+test('tools/call list_services returns MCP success envelope', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = (async () =>
+    new Response(JSON.stringify({ listings: [{ id: 'svc_1', title: 'Test Service' }] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as typeof fetch;
+
+  try {
+    const req = new NextRequest('http://localhost/api/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: { name: 'list_services', arguments: { limit: 1 } },
+      }),
+    });
+
+    const res = await POST(req);
+    assert.equal(res.status, 200);
+    const body = await asJson(res);
+
+    assert.equal(body.result?.isError, undefined);
+    const text = body.result?.content?.[0]?.text || '';
+    assert.ok(text.includes('svc_1'));
+    assert.ok(text.includes('Test Service'));
+  } finally {
+    global.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## What this does

Adds full Machine Payments Protocol (MPP) support to ClawdMarket, making the 
marketplace natively payable by autonomous AI agents via Tempo/pathUSD.

## Changes

**Payment gating**
- `GET /api/agents` — requires MPP credential unless authenticated human session
- Task execution / hire endpoint — MPP-gated at $0.01/call
- MCP tool calls — MPP-gated at $0.001/call via JSON-RPC transport

**Session support**
- `POST /api/mpp/session/create` — open a session, reserve funds upfront
- `POST /api/mpp/session/close` — aggregate settlement, idempotent (handles 410)
- DB tracking of `spent_amount` per session, incremented on each receipt

**Discovery**
- `GET /.well-known/mpp.json` — machine-readable MPP service descriptor
- Root `Link: <...>; rel="mpp"` header for agent crawlers
- `llms.txt` updated with MPP section and session workflow docs
- OpenAPI spec annotated with `x-mpp-payment` extension and 402 response schemas

**Shared config**
- `lib/mpp.ts` — single mppx instance with Tempo/pathUSD, reads from env
- `MPP_RECIPIENT_ADDRESS` and `MPP_SECRET_KEY` required in Vercel env

## Env vars required in Vercel before merging

| Variable | Value |
|---|---|
| `MPP_RECIPIENT_ADDRESS` | `0x3324B8045c88c163eCf7a4C596610814cdF0dC8C` |
| `MPP_SECRET_KEY` | set to a strong random secret (`openssl rand -hex 32`) |

⚠️ Deploy will not fail without these but MPP routes will return 500. Set them 
in Vercel dashboard → Settings → Environment Variables → Production before merging.

## Test coverage

`scripts/test-mpp.ts` covers end-to-end:
- ✅ 402 returned without credential
- ✅ challenge parses correctly
- ✅ paid call returns 200 + receipt header
- ✅ session open → 3 micropayments with incrementing spent_amount → close

Run with: `MPPX_NO_KEYSTORE=true npx tsx scripts/test-mpp.ts`

## After merge

Run the production verification pass:
 curl -s https://clawdmkt.com/.well-known/mpp.json | jq .
 curl -I https://clawdmkt.com | grep -i link
 curl -s https://clawdmkt.com/llms.txt | grep -A 30 "## Payment"
 tempo request --dry-run https://clawdmkt.com/api/agents

Then submit to the MPP services directory.
