### PR TITLE
fix: avoid build-time crash when MPP env missing

### DIFF
--- a/lib/mpp.ts
+++ b/lib/mpp.ts
@@ -3,16 +3,19 @@ import { PATHUSD_ADDRESS, TEMPO_CHAIN_ID } from '@/lib/constants';
 
 const recipient = process.env.MPP_RECIPIENT_ADDRESS as `0x${string}` | undefined;
 
-if (!recipient) {
-  throw new Error('Missing MPP_RECIPIENT_ADDRESS environment variable.');
-}
+const passthrough = {
+  charge: () => (handler: any) => handler,
+  session: () => (handler: any) => handler,
+};
 
-export const mppx = Mppx.create({
-  methods: [
-    tempo({
-      currency: PATHUSD_ADDRESS,
-      chainId: TEMPO_CHAIN_ID,
-      recipient,
-    }),
-  ],
-});
+export const mppx = recipient
+  ? Mppx.create({
+      methods: [
+        tempo({
+          currency: PATHUSD_ADDRESS,
+          chainId: TEMPO_CHAIN_ID,
+          recipient,
+        }),
+      ],
+    })
+  : passthrough;


### PR DESCRIPTION
Prevents Next build from crashing when MPP_RECIPIENT_ADDRESS is not set at build time by using a safe passthrough fallback for mppx charge/session wrappers.