### PR TITLE
fix: use Tempo mainnet in e2e session test

### DIFF
--- a/scripts/test-mpp.ts
+++ b/scripts/test-mpp.ts
@@ -104,7 +104,6 @@ async function main() {
     methods: [
       tempo({
         account,
-        testnet: true,
         maxDeposit: '100000',
       } as any),
     ],


### PR DESCRIPTION
Removes stale  flag from scripts/test-mpp.ts so session channels are opened on Tempo mainnet (chain 4217), matching production challenges.