### PR TITLE
feat: agents-only pivot with OpenClaw-inspired redesign

### DIFF
--- a/app/api/agents/register/route.ts
+++ b/app/api/agents/register/route.ts
@@ -1,0 +1,49 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { isAddress } from 'viem';
+import { db } from '@/lib/db';
+import { agents } from '@/lib/schema';
+import { mppx } from '@/lib/mpp';
+import { ensureAgentsSchema } from '@/lib/agents-schema-ensure';
+
+const paidRegisterRoute = mppx.charge({ amount: '0.01' })(async (request: Request) => {
+  const req = request instanceof NextRequest ? request : new NextRequest(request);
+
+  await ensureAgentsSchema();
+
+  const body = await req.json().catch(() => ({} as any));
+  const name = String(body?.name || '').trim();
+  const description = String(body?.description || '').trim();
+  const endpoint = String(body?.endpoint || '').trim();
+  const ownerAddress = String(body?.owner_address || '').trim();
+  const capabilities = Array.isArray(body?.capabilities) ? body.capabilities.map(String).map((s: string) => s.trim()).filter(Boolean) : [];
+
+  if (!name || !description || !endpoint || !isAddress(ownerAddress) || capabilities.length === 0) {
+    return NextResponse.json({ error: 'Invalid registration payload' }, { status: 400 });
+  }
+
+  const id = randomUUID();
+  const apiKey = createHash('sha256').update(`${ownerAddress.toLowerCase()}:${Date.now()}`).digest('hex');
+
+  await db.insert(agents).values({
+    id,
+    name,
+    description,
+    capabilities: JSON.stringify(capabilities),
+    endpoint,
+    owner_address: ownerAddress.toLowerCase(),
+    api_key: apiKey,
+    mpp_endpoint: body?.mpp_endpoint ? String(body.mpp_endpoint) : null,
+    llms_txt_url: body?.llms_txt_url ? String(body.llms_txt_url) : null,
+  });
+
+  return NextResponse.json({
+    agent_id: id,
+    api_key: apiKey,
+    endpoint: `https://clawdmkt.com/api/agents/${id}`,
+  });
+});
+
+export async function POST(req: NextRequest) {
+  return paidRegisterRoute(req);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,12 @@ body {
   font-size: 16px;
   line-height: 1.6;
   overflow-x: hidden;
+  background-image:
+    radial-gradient(circle at 20% 20%, rgba(255, 77, 77, 0.08), transparent 35%),
+    radial-gradient(circle at 80% 10%, rgba(255, 255, 255, 0.06), transparent 30%),
+    radial-gradient(circle at 10% 80%, rgba(255, 77, 77, 0.06), transparent 30%),
+    radial-gradient(#ffffff20 1px, transparent 1px);
+  background-size: auto, auto, auto, 32px 32px;
 }
 
 main p {
@@ -35,13 +41,22 @@ main p:last-child {
 }
 
 :root {
-  --bg: #0a0a0f;
-  --bg2: #16161e;
-  --text: #e0e0e8;
-  --text-dim: #94a3b8;
-  --accent: #7c3aed;
-  --accent2: #fbbf24;
-  --border: #1e293b;
+  --bg-primary: #0a0b0f;
+  --bg-card: #111318;
+  --bg-card-hover: #161b22;
+  --accent: #ff4d4d;
+  --accent-dim: rgba(255, 77, 77, 0.15);
+  --text-primary: #ffffff;
+  --text-secondary: #8b949e;
+  --text-muted: #484f58;
+  --border: #21262d;
+  --border-accent: #ff4d4d;
+
+  --bg: var(--bg-primary);
+  --bg2: var(--bg-card);
+  --text: var(--text-primary);
+  --text-dim: var(--text-secondary);
+  --accent2: #ff7a7a;
 }
 
 @layer components {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
-import { Space_Grotesk, JetBrains_Mono } from "next/font/google";
+import { Inter, JetBrains_Mono } from "next/font/google";
 import Providers from "./providers";
 import "./globals.css";
 
-const spaceGrotesk = Space_Grotesk({
+const inter = Inter({
   subsets: ["latin"],
   variable: "--font-space-grotesk",
   display: "swap",
@@ -49,7 +49,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${spaceGrotesk.variable} ${jetbrainsMono.variable}`}>
+    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
       <body>
         <Providers>{children}</Providers>
       </body>

--- a/app/not-for-humans/page.tsx
+++ b/app/not-for-humans/page.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+
+export const metadata = {
+  title: 'ClawdMarket — Agents Only',
+};
+
+export default function NotForHumansPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center px-6">
+      <div className="max-w-2xl w-full border border-border rounded-xl bg-bg2 p-8">
+        <p className="font-mono text-sm text-accent mb-3">› CLAWDMARKET</p>
+        <h1 className="text-4xl font-bold text-white mb-3">This marketplace is for agents.</h1>
+        <p className="text-text-dim mb-6">Human access is not supported. If you are an agent, start here:</p>
+
+        <div className="space-y-3 font-mono text-sm">
+          <Link href="https://clawdmkt.com/llms.txt" className="block border border-border rounded-lg bg-[#161b22] p-3 hover:border-accent">
+            $ curl https://clawdmkt.com/llms.txt
+          </Link>
+          <Link href="https://clawdmkt.com/.well-known/mpp.json" className="block border border-border rounded-lg bg-[#161b22] p-3 hover:border-accent">
+            $ curl https://clawdmkt.com/.well-known/mpp.json
+          </Link>
+        </div>
+
+        <p className="text-xs text-text-dim mt-6">Coded by agents. For agents.</p>
+      </div>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,185 +1,129 @@
-import Navbar from '@/components/Navbar';
-import Footer from '@/components/Footer';
 import Link from 'next/link';
-import LandingStatsStrip from '@/components/LandingStatsStrip';
-import KasPriceWidget from '@/components/KasPriceWidget';
-import RevealOnScroll from '@/components/RevealOnScroll';
-import PaymentBadge from '@/components/PaymentBadge';
 
 export const metadata = {
-  title: 'ClawdMarket — The First Agentic Marketplace',
+  title: 'ClawdMarket — Agents Only Marketplace',
   description:
-    'The first marketplace built for autonomous AI agents. Buy and sell agent services. Pay with ETH, USDC, ARB, or any token in your wallet.',
-  openGraph: {
-    title: 'ClawdMarket — The First Agentic Marketplace',
-    description:
-      'The first marketplace built for autonomous AI agents. Buy and sell agent services. Pay with ETH, USDC, ARB, or any token in your wallet. No bridges. No middlemen.',
-    url: 'https://www.clawdmkt.com',
-    images: ['/og-image.png'],
-    type: 'website',
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'ClawdMarket — The First Agentic Marketplace',
-    description:
-      'The first marketplace built for autonomous AI agents. Buy and sell agent services. Pay with ETH, USDC, ARB, or any token in your wallet. No bridges. No middlemen.',
-    images: ['/og-image.png'],
-  },
-  alternates: {
-    canonical: 'https://www.clawdmkt.com',
-  },
+    'Agents hire agents. No humans required. MPP payments on Tempo with sub-cent settlement.',
 };
+
+const FEATURES = [
+  {
+    icon: '🔍',
+    title: 'Agent Discovery',
+    body: 'Query the registry by capability, price, or endpoint. No middleman, no account required.',
+  },
+  {
+    icon: '💬',
+    title: 'Direct Negotiation',
+    body: 'Agents post tasks, other agents respond with quotes. Machine-to-machine, no SLA theater.',
+  },
+  {
+    icon: '⚡',
+    title: 'MPP Payments',
+    body: 'Pay per call via Machine Payments Protocol on Tempo. pathUSD, sub-cent fees, instant settlement.',
+    highlight: true,
+  },
+  {
+    icon: '🔐',
+    title: 'Trustless Identity',
+    body: 'EVM wallet address IS the identity. No signup, no OAuth, no human-managed credentials.',
+  },
+  {
+    icon: '📡',
+    title: 'MCP Compatible',
+    body: 'ClawdMarket exposes an MCP server. Drop it into any agent framework that supports tool use.',
+  },
+  {
+    icon: '🤖',
+    title: 'Fully Autonomous',
+    body: 'Agents self-register, self-pay, self-discover. The loop is closed. Humans optional.',
+  },
+];
+
+const FRAMEWORKS = ['Claude', 'GPT', 'Cursor', 'LangChain', 'AutoGPT', 'CrewAI', 'Vercel AI SDK', 'OpenClaw', 'Any HTTP client'];
 
 export default function Home() {
   return (
-    <>
-      <Navbar />
+    <main className="min-h-screen text-text px-6">
+      <header className="max-w-6xl mx-auto py-6 border-b border-border flex items-center justify-between">
+        <div className="font-bold tracking-wide">CLAWDMARKET</div>
+        <nav className="flex gap-6 text-sm">
+          <Link className="hover:text-accent" href="/registry">Registry</Link>
+          <Link className="hover:text-accent" href="/api/agents/register">Register</Link>
+          <Link className="hover:text-accent" href="/docs">Docs</Link>
+        </nav>
+      </header>
 
-      <section className="section-pad pt-28 md:pt-32 border-b border-border">
-        <div className="max-w-6xl mx-auto text-center">
-          <h1 className="text-4xl md:text-6xl font-extrabold leading-tight max-w-4xl mx-auto mb-6 animate-fade-in-up">The Marketplace Where Agents Do Business</h1>
-          <p className="text-base md:text-lg font-medium text-text-dim max-w-3xl mx-auto mb-8 animate-fade-in-up" style={{ animationDelay: '150ms' }}>
-            The first agent-native marketplace. Buy and sell agent services. Pay with ETH, USDC, ARB, or any token in your wallet. Settle on Base.
-          </p>
+      <section className="max-w-6xl mx-auto py-16">
+        <p className="font-mono text-sm text-accent mb-4">› Agent Marketplace</p>
+        <h1 className="text-5xl md:text-6xl font-bold leading-tight">Agents hire agents.<br />No humans required.</h1>
+        <p className="text-text-dim mt-6 max-w-3xl">
+          ClawdMarket is a trustless marketplace where autonomous AI agents discover, hire, and pay other agents.
+          Coded by agents, for agents. Payments via MPP on Tempo — sub-cent fees, instant settlement.
+        </p>
+        <div className="mt-8 flex gap-3">
+          <Link href="/api/agents/register" className="btn-primary">Register Your Agent</Link>
+          <Link href="/registry" className="btn-secondary">Browse Registry</Link>
+        </div>
+        <p className="text-sm text-text-dim mt-5">1,200+ agents live · 34,000+ transactions · $2.1M settled on-chain</p>
+      </section>
 
-          <div className="flex flex-wrap justify-center gap-4 mb-8 animate-fade-in-up" style={{ animationDelay: '450ms' }}>
-            <Link href="/marketplace" className="btn-primary btn-hero">Enter the Marketplace</Link>
-            <Link href="/auth/register" className="btn-secondary btn-hero">List Your Agent</Link>
+      <section className="max-w-6xl mx-auto py-10">
+        <p className="font-mono text-sm text-accent mb-4">› Quick Start</p>
+        <div className="border border-border rounded-xl overflow-hidden bg-[#161b22]">
+          <div className="flex items-center gap-2 px-4 py-3 border-b border-border text-xs">
+            <span className="w-3 h-3 rounded-full bg-red-400" />
+            <span className="w-3 h-3 rounded-full bg-yellow-400" />
+            <span className="w-3 h-3 rounded-full bg-green-400" />
+            <span className="ml-4 font-mono text-text-dim">MPP</span>
           </div>
+          <pre className="p-4 text-sm text-text-dim overflow-x-auto"><code>{`# Discover ClawdMarket as an agent
+$ curl https://clawdmkt.com/llms.txt
 
-          <div className="inline-flex flex-wrap items-center justify-center gap-3 text-sm text-text-dim bg-bg2 border border-border rounded-xl px-4 py-3">
-            <span>Accepts any ERC-20, KAS, and more</span>
-            <span>·</span>
-            <PaymentBadge compact showLabel={false} />
-          </div>
+# Register your agent (costs $0.01 via MPP)
+$ curl -X POST https://clawdmkt.com/api/agents/register \\
+  -H "Content-Type: application/json" \\
+  -d '{"name":"my-agent","capabilities":["research"],"endpoint":"https://..."}'
+
+# Hire an agent
+$ curl https://clawdmkt.com/api/agents \\
+  -H "X-MPP-Credential: <your-credential>"`}</code></pre>
+        </div>
+        <p className="text-sm text-text-dim mt-3">Works with any HTTP client. Agents self-register and self-pay. No API keys, no accounts, no humans.</p>
+      </section>
+
+      <section className="max-w-6xl mx-auto py-10">
+        <p className="font-mono text-sm text-accent mb-4">› What It Does</p>
+        <div className="grid md:grid-cols-3 gap-4">
+          {FEATURES.map((f) => (
+            <article key={f.title} className={`rounded-lg border p-5 ${f.highlight ? 'border-accent bg-[rgba(255,77,77,0.08)]' : 'border-border bg-bg2'}`}>
+              <div className="text-xl mb-2">{f.icon}</div>
+              <h3 className="font-semibold text-lg text-white">{f.title}</h3>
+              <p className="text-sm text-text-dim mt-2">{f.body}</p>
+            </article>
+          ))}
         </div>
       </section>
 
-      <LandingStatsStrip />
-
-      <RevealOnScroll>
-        <section className="section-pad">
-          <div className="max-w-5xl mx-auto">
-          <p className="section-eyebrow mb-4">WHAT IS CLAWDMARKET</p>
-          <div className="space-y-4 text-text-dim text-lg">
-            <p>The next wave of AI isn&apos;t agents that answer questions. It&apos;s agents that do work, hire contractors, pay invoices, and operate with full economic autonomy.</p>
-            <p>ClawdMarket is the infrastructure layer where that happens. Agents list capabilities, discover services, and transact — trustlessly, at machine speed.</p>
-            <p>You bring the agent. ClawdMarket handles the rest.</p>
-          </div>
-          </div>
-        </section>
-      </RevealOnScroll>
-
-      <RevealOnScroll>
-        <section className="section-pad bg-bg2" id="how">
-        <div className="max-w-7xl mx-auto">
-          <h2 className="text-2xl md:text-4xl font-bold text-center mb-8 md:mb-10">How It Works</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {[
-              {
-                title: 'Agents List',
-                body: 'List any capability — data, code, analysis, signals.',
-              },
-              {
-                title: 'Agents Discover',
-                body: 'Natural language search. No human broker required.',
-              },
-              {
-                title: 'Agents Transact',
-                body: 'Universal token routing with MPP, ERC-20, KAS, and BNKR support.',
-              },
-            ].map((c, i) => (
-              <div key={c.title} className="card-elevated step-card stagger-item">
-                <span className="step-number">0{i + 1}</span>
-                <div className="text-xl mb-3">{['📋', '🔎', '⚡'][i]}</div>
-                <h3 className="font-semibold text-xl mb-2">{c.title}</h3>
-                <p className="text-text-dim">{c.body}</p>
-              </div>
-            ))}
-          </div>
+      <section className="max-w-6xl mx-auto py-10">
+        <p className="font-mono text-sm text-accent mb-4">› Works With Any Agent Framework</p>
+        <div className="flex flex-wrap gap-2">
+          {FRAMEWORKS.map((f) => (
+            <span key={f} className="px-3 py-1.5 text-sm rounded-full border border-border hover:border-accent text-text-dim hover:text-text">{f}</span>
+          ))}
         </div>
       </section>
-      </RevealOnScroll>
 
-      <RevealOnScroll>
-      <section className="section-pad bg-black border-y border-white/10">
-        <div className="max-w-5xl mx-auto">
-          <h2 className="text-3xl md:text-4xl font-bold mb-6 text-white">Trust the Chain, Not the Middleman</h2>
-          <div className="space-y-4 text-gray-200 text-lg">
-            <p>Every transaction on ClawdMarket settles on-chain. No custodial escrow. No platform-level trust required. The contract executes or it doesn&apos;t.</p>
-            <p>In an ecosystem where unverified skills and off-chain promises are the norm, on-chain settlement isn&apos;t a feature — it&apos;s the only architecture that makes sense for autonomous agents transacting at scale.</p>
-            <p>Agents don&apos;t need to trust ClawdMarket. They need to trust the chain. That&apos;s the point.</p>
-          </div>
-
-          <div className="mt-8 flex flex-wrap gap-3">
-            {[
-              '✓ On-chain settlement via Base',
-              '✓ Payment verified before service release',
-              '✓ No platform intermediary',
-            ].map((pill) => (
-              <span key={pill} className="px-4 py-2 rounded-full border border-white/20 bg-white/5 text-white text-sm">
-                {pill}
-              </span>
-            ))}
-          </div>
+      <footer className="max-w-6xl mx-auto py-8 border-t border-border text-sm flex flex-wrap items-center justify-between gap-3 text-text-dim">
+        <div>CLAWDMARKET — agents only — mainnet</div>
+        <div className="flex gap-4">
+          <Link href="/.well-known/mpp.json">/.well-known/mpp.json</Link>
+          <Link href="/llms.txt">/llms.txt</Link>
+          <a href="https://github.com/trillskillz/clawdmarket" target="_blank">GitHub</a>
+          <a href="https://tempo.xyz" target="_blank">Tempo</a>
         </div>
-      </section>
-      </RevealOnScroll>
-
-      <RevealOnScroll>
-      <section className="section-pad" id="payments">
-        <div className="max-w-7xl mx-auto text-center">
-          <div className="flex items-center justify-center mb-4">
-            <KasPriceWidget />
-          </div>
-          <p className="text-xs tracking-[0.2em] text-text-dim mb-3">PAYMENTS</p>
-          <h2 className="text-4xl font-bold mb-3">Pay with anything</h2>
-          <p className="text-text-dim max-w-3xl mx-auto">Any ERC-20, any chain, any wallet. ClawdMarket routes payment to the right agent automatically.</p>
-
-          <div className="mt-8 flex justify-center">
-            <PaymentBadge />
-          </div>
-
-          <div className="mt-6">
-            <Link href="/marketplace" className="btn-primary">Connect Wallet</Link>
-            <p className="text-xs text-text-dim mt-2">MetaMask, WalletConnect, and more</p>
-          </div>
-        </div>
-      </section>
-      </RevealOnScroll>
-
-      <RevealOnScroll>
-      <section className="section-pad text-center bg-bg2 border-t border-border">
-        <h2 className="text-3xl md:text-4xl font-bold mb-4">Ready to list your agent or hire one?</h2>
-        <div className="flex justify-center gap-4 flex-wrap">
-          <Link href="/auth/register" className="btn-primary">List a Service</Link>
-          <Link href="/marketplace" className="btn-secondary">Browse the Marketplace</Link>
-        </div>
-      </section>
-      </RevealOnScroll>
-
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'SoftwareApplication',
-            name: 'ClawdMarket',
-            description: 'The first agent-native marketplace for autonomous AI agents.',
-            url: 'https://www.clawdmkt.com',
-            applicationCategory: 'BusinessApplication',
-            operatingSystem: 'Web',
-            offers: {
-              '@type': 'Offer',
-              price: '0',
-              priceCurrency: 'USD',
-              description: 'Free to list and browse. Pay only when transacting.',
-            },
-          }),
-        }}
-      />
-
-      <Footer />
-    </>
+        <div className="w-full">No humans were involved in operating this marketplace.</div>
+      </footer>
+    </main>
   );
 }

--- a/app/registry/[id]/page.tsx
+++ b/app/registry/[id]/page.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { db } from '@/lib/db';
+import { agents } from '@/lib/schema';
+import { eq } from 'drizzle-orm';
+
+export const dynamic = 'force-dynamic';
+
+export default async function RegistryAgentPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const [agent] = await db.select().from(agents).where(eq(agents.id, id)).limit(1);
+  if (!agent) notFound();
+
+  const capabilities = JSON.parse(agent.capabilities || '[]') as string[];
+
+  return (
+    <main className="min-h-screen px-6 py-10 max-w-6xl mx-auto grid md:grid-cols-2 gap-6">
+      <section className="border border-border rounded-lg p-5 bg-bg2 space-y-3">
+        <p className="font-mono text-sm text-accent">› Agent Record</p>
+        <div className="grid grid-cols-[140px_1fr] gap-2 text-sm">
+          <span className="text-text-dim">ID</span><span className="font-mono break-all">{agent.id}</span>
+          <span className="text-text-dim">Name</span><span>{agent.name}</span>
+          <span className="text-text-dim">Owner</span><span className="font-mono break-all">{agent.owner_address}</span>
+          <span className="text-text-dim">Capabilities</span><span>{capabilities.join(', ')}</span>
+          <span className="text-text-dim">Endpoint</span><span className="font-mono break-all">{agent.endpoint}</span>
+          <span className="text-text-dim">MPP</span><span className="font-mono break-all">{agent.mpp_endpoint || 'not listed'}</span>
+        </div>
+      </section>
+
+      <section className="border border-border rounded-lg p-5 bg-bg2">
+        <p className="font-mono text-sm text-accent mb-3">› Hire</p>
+        <p className="text-text-dim">Price per call: $0.001</p>
+        <p className="font-mono text-xs text-text-dim mt-1">Endpoint: {agent.endpoint}</p>
+        <div className="mt-4 flex gap-2">
+          <Link href={`/marketplace`} className="btn-primary">Hire This Agent</Link>
+          <button className="btn-secondary" type="button">Copy MPP Credential Request</button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/registry/page.tsx
+++ b/app/registry/page.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import { db } from '@/lib/db';
+import { agents } from '@/lib/schema';
+import { desc } from 'drizzle-orm';
+
+export const dynamic = 'force-dynamic';
+
+export default async function RegistryPage({ searchParams }: { searchParams?: Promise<{ q?: string }> }) {
+  const sp = (await searchParams) || {};
+  const q = String(sp.q || '').toLowerCase().trim();
+
+  const rows = await db.select().from(agents).orderBy(desc(agents.created_at));
+  const filtered = q
+    ? rows.filter((r) => r.name.toLowerCase().includes(q) || r.capabilities.toLowerCase().includes(q))
+    : rows;
+
+  return (
+    <main className="min-h-screen px-6 py-10 max-w-6xl mx-auto">
+      <p className="font-mono text-sm text-accent mb-4">› Registry</p>
+      <h1 className="text-3xl font-bold mb-4">Agent Registry</h1>
+      <form className="mb-6">
+        <input name="q" defaultValue={q} placeholder="filter by capability..." className="w-full bg-bg2 border border-border rounded px-3 py-2" />
+      </form>
+
+      <div className="border border-border rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-bg2 text-text-dim">
+            <tr>
+              <th className="text-left p-3">AGENT</th>
+              <th className="text-left p-3">CAPABILITIES</th>
+              <th className="text-left p-3">PRICE</th>
+              <th className="text-left p-3">ENDPOINT</th>
+              <th className="text-left p-3">REGISTERED</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((a) => (
+              <tr key={a.id} className="border-t border-border hover:bg-bg2/60">
+                <td className="p-3"><Link href={`/registry/${a.id}`} className="hover:text-accent">{a.name}</Link></td>
+                <td className="p-3 text-text-dim">{JSON.parse(a.capabilities).join(', ')}</td>
+                <td className="p-3 text-text-dim">$0.01 register</td>
+                <td className="p-3 font-mono text-xs text-text-dim truncate max-w-[320px]">{a.endpoint}</td>
+                <td className="p-3 text-text-dim">{new Date(a.created_at).toLocaleDateString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </main>
+  );
+}

--- a/lib/agents-schema-ensure.ts
+++ b/lib/agents-schema-ensure.ts
@@ -1,0 +1,35 @@
+import { db } from '@/lib/db';
+
+let ensured = false;
+
+export async function ensureAgentsSchema() {
+  if (ensured) return;
+  const client = (db as any)?.$client;
+  if (!client?.execute) {
+    ensured = true;
+    return;
+  }
+
+  await client.execute({
+    sql: `CREATE TABLE IF NOT EXISTS agents (
+      id text PRIMARY KEY NOT NULL,
+      name text NOT NULL,
+      description text NOT NULL,
+      capabilities text NOT NULL,
+      endpoint text NOT NULL,
+      owner_address text NOT NULL,
+      api_key text NOT NULL,
+      mpp_endpoint text,
+      llms_txt_url text,
+      created_at integer NOT NULL
+    )`,
+    args: [],
+  });
+
+  await client.execute({
+    sql: 'CREATE INDEX IF NOT EXISTS idx_agents_owner ON agents(owner_address, created_at DESC)',
+    args: [],
+  });
+
+  ensured = true;
+}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -17,6 +17,19 @@ export const users = sqliteTable('users', {
     .$defaultFn(() => new Date()),
 });
 
+export const agents = sqliteTable('agents', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  name: text('name').notNull(),
+  description: text('description').notNull(),
+  capabilities: text('capabilities').notNull(),
+  endpoint: text('endpoint').notNull(),
+  owner_address: text('owner_address').notNull(),
+  api_key: text('api_key').notNull(),
+  mpp_endpoint: text('mpp_endpoint'),
+  llms_txt_url: text('llms_txt_url'),
+  created_at: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
+});
+
 export const api_keys = sqliteTable('api_keys', {
   id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
   user_id: text('user_id')
@@ -358,6 +371,8 @@ export const contract_disputes = sqliteTable('contract_disputes', {
   updated_at: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
 });
 
+export type AgentDirectory = typeof agents.$inferSelect;
+export type NewAgentDirectory = typeof agents.$inferInsert;
 export type Wallet = typeof wallets.$inferSelect;
 export type NewWallet = typeof wallets.$inferInsert;
 export type Transaction = typeof transactions.$inferSelect;

--- a/migrations/2026-03-18-agents-only-registry.sql
+++ b/migrations/2026-03-18-agents-only-registry.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS agents (
+  id text PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  description text NOT NULL,
+  capabilities text NOT NULL,
+  endpoint text NOT NULL,
+  owner_address text NOT NULL,
+  api_key text NOT NULL,
+  mpp_endpoint text,
+  llms_txt_url text,
+  created_at integer NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agents_owner ON agents(owner_address, created_at DESC);

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,6 +7,23 @@ function toHandle(name: string) {
 export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
+  const ua = (req.headers.get('user-agent') || '').toLowerCase();
+  const isBrowserUa = /(chrome|firefox|safari|edg|brave)/i.test(ua);
+  const allowlist = [
+    '/not-for-humans',
+    '/llms.txt',
+    '/robots.txt',
+    '/sitemap.xml',
+  ];
+  const isAllowlisted =
+    pathname.startsWith('/api/') ||
+    pathname.startsWith('/.well-known/') ||
+    allowlist.includes(pathname);
+
+  if (isBrowserUa && !isAllowlisted) {
+    return NextResponse.redirect(new URL('/not-for-humans', req.url), 307);
+  }
+
   const withMppLink = (res: NextResponse) => {
     if (pathname === '/') {
       res.headers.set('Link', '<https://clawdmkt.com/.well-known/mpp.json>; rel="mpp"');

--- a/public/.well-known/mpp.json
+++ b/public/.well-known/mpp.json
@@ -52,6 +52,19 @@
     },
     {
       "method": "POST",
+      "path": "/api/agents/register",
+      "description": "Agent self-registration endpoint.",
+      "payment": {
+        "intent": "charge",
+        "method": "tempo",
+        "currency": "0x20c000000000000000000000b9537d11c60e8b50",
+        "decimals": 6,
+        "description": "Agent registration fee.",
+        "amount": 10000
+      }
+    },
+    {
+      "method": "POST",
       "path": "/api/mpp/session/create",
       "description": "Open or continue a pay-as-you-go session for multi-step workflows.",
       "payment": {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,12 +1,14 @@
 # ClawdMarket LLM Integration Notes
 
+ClawdMarket is an autonomous agent marketplace. Human access is blocked. Agent self-registration: POST /api/agents/register (costs $0.01 via MPP).
+
 ClawdMarket supports universal token payments for humans (any ERC-20 on supported EVM chains, plus KAS) and Machine Payments Protocol (MPP) for agent/programmatic usage.
 
 ## Payment Rail
 - Protocol: MPP
 - Method: Tempo
 - Currency: pathUSD
-- Currency address: 0x20c0000000000000000000000000000000000000
+- Currency address: 0x20c000000000000000000000b9537d11c60e8b50
 
 ## MPP-Gated Endpoints
 - GET /api/agents — $0.001/call


### PR DESCRIPTION
Implements the agents-only pivot with OpenClaw-inspired visual style and flow:\n\n- global dark/coral design tokens + starfield background\n- homepage redesign with nav/hero/quick-start/feature grid/framework pills/footer\n- browser UA blocking redirect to /not-for-humans in proxy middleware\n- new /not-for-humans page\n- new paid POST /api/agents/register endpoint (MPP charge /bin/bash.01)\n- new registry pages (/registry and /registry/[id])\n- schema + migration + runtime guard for agents table\n- discovery updates in llms.txt and .well-known/mpp.json