### PR TITLE
fix: include Mozilla UA in browser redirect detection

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,7 +7,7 @@ function toHandle(name: string) {
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
   const ua = (req.headers.get('user-agent') || '').toLowerCase();
-  const isBrowserUa = /(chrome|firefox|safari|edg|brave)/i.test(ua);
+  const isBrowserUa = /(mozilla|chrome|firefox|safari|edg|brave|opera)/i.test(ua);
 
   const isAllowlisted =
     pathname === '/not-for-humans' ||


### PR DESCRIPTION
Ensures curl checks using -A 'Mozilla/5.0' get redirected to /not-for-humans as expected.