### PR TITLE
chore: fix workspace root lockfile conflict

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  outputFileTracingRoot: __dirname,
   webpack: (config) => {
     config.resolve = config.resolve || {};
     config.resolve.alias = {


### PR DESCRIPTION
Removes workspace root warning by cleaning stale root lockfile/node_modules and adding outputFileTracingRoot in Next config for deterministic root resolution.