### PR TITLE
fix: registry DB fallback and add solana price endpoint

### DIFF
--- a/app/api/payments/solana/price/route.ts
+++ b/app/api/payments/solana/price/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const res = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=solana&vs_currencies=usd', {
+    next: { revalidate: 60 },
+  });
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(
+    { sol_usd: Number(data?.solana?.usd || 0), timestamp: new Date().toISOString() },
+    { headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=60' } },
+  );
+}

--- a/app/registry/[id]/page.tsx
+++ b/app/registry/[id]/page.tsx
@@ -1,14 +1,16 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { db } from '@/lib/db';
-import { agents } from '@/lib/schema';
 import { eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { ensureAgentsSchema } from '@/lib/agents-schema-ensure';
+import { agents } from '@/lib/schema';
 
 export const dynamic = 'force-dynamic';
 
 export default async function RegistryAgentPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const [agent] = await db.select().from(agents).where(eq(agents.id, id)).limit(1);
+  await ensureAgentsSchema();
+  const [agent] = await db.select().from(agents).where(eq(agents.id, id)).limit(1).catch(() => [] as any[]);
   if (!agent) notFound();
 
   const capabilities = JSON.parse(agent.capabilities || '[]') as string[];
@@ -32,7 +34,7 @@ export default async function RegistryAgentPage({ params }: { params: Promise<{ 
         <p className="text-text-dim">Price per call: $0.001</p>
         <p className="font-mono text-xs text-text-dim mt-1">Endpoint: {agent.endpoint}</p>
         <div className="mt-4 flex gap-2">
-          <Link href={`/marketplace`} className="btn-primary">Hire This Agent</Link>
+          <Link href="/marketplace" className="btn-primary">Hire This Agent</Link>
           <button className="btn-secondary" type="button">Copy MPP Credential Request</button>
         </div>
       </section>

--- a/app/registry/page.tsx
+++ b/app/registry/page.tsx
@@ -1,7 +1,8 @@
 import Link from 'next/link';
-import { db } from '@/lib/db';
-import { agents } from '@/lib/schema';
 import { desc } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { ensureAgentsSchema } from '@/lib/agents-schema-ensure';
+import { agents } from '@/lib/schema';
 
 export const dynamic = 'force-dynamic';
 
@@ -9,7 +10,8 @@ export default async function RegistryPage({ searchParams }: { searchParams?: Pr
   const sp = (await searchParams) || {};
   const q = String(sp.q || '').toLowerCase().trim();
 
-  const rows = await db.select().from(agents).orderBy(desc(agents.created_at));
+  await ensureAgentsSchema();
+  const rows = await db.select().from(agents).orderBy(desc(agents.created_at)).catch(() => [] as any[]);
   const filtered = q
     ? rows.filter((r) => r.name.toLowerCase().includes(q) || r.capabilities.toLowerCase().includes(q))
     : rows;


### PR DESCRIPTION
Prevents registry 500s when agents table is unavailable by ensuring schema + fallback; adds /api/payments/solana/price for verification tooling.